### PR TITLE
fix(northbrook): fix commit and release for scoped packages

### DIFF
--- a/src/plugin/commit/index.js
+++ b/src/plugin/commit/index.js
@@ -2,7 +2,7 @@ import { join } from 'path'
 import { types } from 'conventional-commit-types'
 import { prompt } from 'inquirer'
 
-import { isInitialized, exec, clear } from '../../util'
+import { isInitialized, exec, clear, filterScopes } from '../../util'
 
 import { getQuestions } from './getQuestions'
 import { buildCommit } from './buildCommit'
@@ -60,7 +60,7 @@ function commit (commitMsg, gitArgs) {
 }
 
 function packageToScopeName (packageName, workingDir) {
-  const name = require(join(workingDir, packageName, 'package.json')).name
+  const name = filterScopes(require(join(workingDir, packageName, 'package.json')).name)
   return { name, value: name }
 }
 

--- a/src/plugin/release/check-release.js
+++ b/src/plugin/release/check-release.js
@@ -79,6 +79,8 @@ export function getStatus (packages, commits) {
   for (let i = commits.length - 1; i >= 0; --i) {
     const commit = commits[i]
 
+    console.log(commit)
+
     if (packages.indexOf(commit.scope) === -1) continue
 
     const packageName = commit.scope
@@ -104,6 +106,7 @@ export function getStatus (packages, commits) {
     }
   }
 
+  console.log(status)
   return status
 }
 
@@ -121,6 +124,7 @@ export function rawCommits (tag) {
     gitRawCommits({ format: '%B%n-hash-%n%H', from: tag })
       .pipe(commitsParser())
       .pipe(concat(function (data) {
+        console.log(data)
         const commits = commitsFilter(data)
         if (!commits || !commits.length) {
           reject(null)

--- a/src/plugin/release/index.js
+++ b/src/plugin/release/index.js
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { readFileSync } from 'fs'
 import { exec as execSync } from 'shelljs'
-import { isInitialized, isFile, exec, chdir, separator, log, splitVersion } from '../../util'
+import { isInitialized, isFile, exec, chdir, separator, log, splitVersion, filterScopes } from '../../util'
 import { start, stop, change_sequence as changeSeq } from 'simple-spinner'
 import { checkRelease } from './check-release'
 import { generateChangelog } from './generate-changelog'
@@ -43,7 +43,7 @@ function action (config, directory, options) {
     throw new Error('Could not switch to ' + releaseBranch)
   }
 
-  const packages = config.packages.map(getPkg(directory))
+  const packages = config.packages.map(getPkg(directory)).map(filterScopes)
 
   checkRelease(packages).then(function (status) {
     const packageNames = Object.keys(status).filter((name) => status[name].increment > 0)
@@ -133,8 +133,7 @@ function action (config, directory, options) {
     function continueReleasing () {
       if (packageNames !== 0) {
         release(packageNames.shift())
-      }
-      if (packageNames.length === 0) {
+      } else if (packageNames.length === 0) {
         console.log('\n All releases complete!\n')
       }
     }

--- a/src/util.js
+++ b/src/util.js
@@ -9,6 +9,8 @@ import findConfig from 'find-config'
 // constants
 const CONFIG = 'northbrook.json'
 
+export const filterScopes = name => name.replace(/@[a-z]+\//g, '')
+
 export function isInitialized (config, commandName) {
   if (!config) {
     throw new Error(`${commandName}: a northbrook.json is required for this command`)

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -3,6 +3,7 @@ import { join } from 'path'
 import assert from 'power-assert'
 
 import {
+  filterScopes,
   getConfig,
   splitVersion,
   exists,
@@ -21,6 +22,18 @@ import {
 } from './util'
 
 describe('util', () => {
+  describe('filterScopes', () => {
+    it('should remove scoped parts of package names', () => {
+      const str = '@northbrook/tslint'
+      assert(filterScopes(str) === 'tslint')
+    })
+
+    it('should leave a non-scoped package name alone', () => {
+      const str = 'tslint'
+      assert(filterScopes(str) === 'tslint')
+    })
+  })
+
   describe('splitVersion', () => {
     it('should split a semver correct version string into 3 parts', () => {
       const [major, minor, patch] = splitVersion('1.2.3')


### PR DESCRIPTION
<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->
- [x] I added new tests for the issue I fixed or the feature I built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

<!--
Please Continue to describe your fix / change citing an issue if possible.
-->

Fixes for when a package is `@scoped` 

A commit message is not parse-able when there is a `@scope/` inside of the scope of the header message.
