### PR TITLE
feat(northbrook): add dependantsOf to DepGraph api

### DIFF
--- a/src/northbrook/northbrook/buildDependencyGraph.test.ts
+++ b/src/northbrook/northbrook/buildDependencyGraph.test.ts
@@ -21,6 +21,25 @@ describe('buildDependencyGraph', () => {
       assert.deepEqual(graph.paths(), [packageA, packageC, packageB, packageD]);
     });
 
+    it('returns all dependants of a package', () => {
+      const packages = [ packageA, packageB, packageC, packageD ];
+
+      const graph = buildDependencyGraph(packages);
+
+      assert.deepEqual(
+          graph.dependantsOf('a-testpackage').sort(),
+          [ 'b-testpackage', 'c-testpackage', 'd-testpackage' ],
+      );
+    });
+
+    it('returns empty dependants when a package lacks dependants', () => {
+      const packages = [ packageA, packageB, packageC, packageD ];
+
+      const graph = buildDependencyGraph(packages);
+
+      assert.deepEqual(graph.dependantsOf('d-testpackage'), []);
+    });
+
     it('throws an error when there is a circular dependency', () => {
       const packages = [ packageE, packageF ];
       const graph = buildDependencyGraph(packages);

--- a/src/northbrook/northbrook/buildDependencyGraph.ts
+++ b/src/northbrook/northbrook/buildDependencyGraph.ts
@@ -57,6 +57,10 @@ export class DepGraph {
     return this.depGraph.dependenciesOf(packageName);
   }
 
+  public dependantsOf (packageName: string): Array<string> {
+    return this.depGraph.dependantsOf(packageName);
+  }
+
   public configOf(packageName: string): Pkg {
     return clone(this.depGraph.getNodeData(packageName));
   }


### PR DESCRIPTION
`DepGraph.dependantsOf` returns dependants of a package, similar to `DepGraph.dependenciesOf`.

`dependantsOf` is absolutely needed for `DepGraph`.

AFFECTS: northbrook

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ x ] I added new tests for the issue I fixed or the feature I built
- [ x ] I ran `npm test` for the package I'm modifying
- [ x ] I used `npm run commit` instead of `git commit`

<!--
Please Continue to describe your fix / change citing an issue if possible.

If there are BREAKING CHANGES, please use one of the following to
communicate the changes that have occured.


This change absolutely will affect users:
![yes](https://img.shields.io/badge/will%20it%20affect%20me%3F-yes-red.svg)

High probability of affecting users:
![probably will](https://img.shields.io/badge/will%20it%20affect%20me%3F-probably%20will-orange.svg)

Will affect more users than not:
![maybe will](https://img.shields.io/badge/will%20it%20affect%20me%3F-maybe%20will-yellow.svg)

Will *not* affect more users than not:
![maybe won't](https://img.shields.io/badge/will%20it%20affect%20me%3F-maybe%20won't-yellowgreen.svg)

Will only affect a few people
![probably won't](https://img.shields.io/badge/will%20it%20affect%20me%3F-probably%20won't-green.svg)

Though breaking, it will almost definitely *not* affect users:
![no](https://img.shields.io/badge/will%20it%20affect%20me%3F-no-brightgreen.svg)
-->
